### PR TITLE
Remove stale dependency, move python version, switch to azure collect…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.9.6"
 
       - name: Install dependencies
         run: |
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.9.6"
 
       - name: Install dependencies
         run: |
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.9.6"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          # Use builtin python version: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#python
+          python-version: "3.9.6"
 
       - name: Install dependencies
         run: |

--- a/Containerfile
+++ b/Containerfile
@@ -30,7 +30,6 @@ RUN /output/install-from-bindep && rm -rf /output/wheels
 RUN alternatives --set python /usr/bin/python3
 COPY --from=quay.io/project-receptor/receptor:1.0.0a2 /usr/bin/receptor /usr/bin/receptor
 RUN mkdir -p /var/run/receptor
-RUN dnf -y update
 ADD run.sh /run.sh
 CMD /run.sh
 USER 1000

--- a/Containerfile
+++ b/Containerfile
@@ -30,6 +30,7 @@ RUN /output/install-from-bindep && rm -rf /output/wheels
 RUN alternatives --set python /usr/bin/python3
 COPY --from=quay.io/project-receptor/receptor:1.0.0a2 /usr/bin/receptor /usr/bin/receptor
 RUN mkdir -p /var/run/receptor
+RUN dnf -y update
 ADD run.sh /run.sh
 CMD /run.sh
 USER 1000

--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -2,8 +2,6 @@
 ansible>=4.0
 # Upstream hasn't packaged as collection yet: https://github.com/TerryHowe/ansible-modules-hashivault/issues/234
 ansible-modules-hashivault
-# Required by hashi_vault PR in to upstream: https://github.com/ansible-collections/community.hashi_vault/pull/105
-hvac
 # Required a number of places including community.general
 jmespath
 # Required by community.general LDAP plugins

--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -1,7 +1,11 @@
 ---
 collections:
   - name: awx.awx
-  - name: azure.azcollection
+# Out until https://github.com/ansible-collections/azure/pull/584 is merged
+#- name: azure.azcollection
+  - name: https://github.com/erinn/azure/
+    type: git
+    version: patch-1
   - name: amazon.aws
   - name: theforeman.foreman
   - name: google.cloud


### PR DESCRIPTION
We have to work off of a fork of azure for a bit and I did some other cleanup in here since hashi_vault set themselves up for ansible builder (bringing in hvac automatically). As well moved to a cached version of python on the runner in order to not waste bandwidth and time.