### PR TITLE
Change package ecosystem to supported value

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,13 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: "python"
+  - package-ecosystem: "pip"
     directory: "/build"
     reviewers:
       - UCBoulder/oit-sepe
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "python"
+  - package-ecosystem: "pip"
     directory: "/spec"
     reviewers:
       - UCBoulder/oit-sepe


### PR DESCRIPTION
Python appears to no longer be a supported value for the package ecosystem.  Updating to 'pip.'