### PR TITLE
ansible-runner pyOpenSSL workaround

### DIFF
--- a/spec/requirements.txt
+++ b/spec/requirements.txt
@@ -1,5 +1,7 @@
 # SEPE-specific, copied from GREQ0302203
 ansible==6.5.0
+# Workaround to address pyOpenSSL version issues with ansible-runner (see https://github.com/ansible/ansible-runner/issues/1138)
+ansible-runner>=2.2.1
 # Upstream hasn't packaged as collection yet: https://github.com/TerryHowe/ansible-modules-hashivault/issues/234
 ansible-modules-hashivault==4.7.0
 # Required a number of places including community.general


### PR DESCRIPTION
Pinning `ansible-runner` to 2.2.1 or greater. Workaround for [this issue](https://github.com/ansible/ansible-runner/issues/1138).