### PR TITLE
Changes related to python 3.8 and ansible versioning

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,9 @@ updates:
       - UCBoulder/oit-sepe
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "ansible"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/spec"
@@ -13,3 +16,6 @@ updates:
       - UCBoulder/oit-sepe
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "ansible"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
  - Be more explicit about python 3.8 usage in test build and deploy build (borrowed from "official" [Ansible awx-ee repository](https://github.com/ansible/awx-ee))

  - Configure dependabot to ignore ansible major version updates